### PR TITLE
feat: add rule-based Korean activity parser

### DIFF
--- a/lib/nlp.js
+++ b/lib/nlp.js
@@ -1,0 +1,83 @@
+import './types.js';
+
+const stopWords = new Set([
+  '오늘', '오전', '저녁', '오후', '그리고', '또', '또는', '에서', '에', '를', '을', '가', '이',
+  '저', '나', '너', '한', '하나', '무슨', '몇', '개', '문항', '1개', '1', '2', '3', '4', '5'
+]);
+
+const tagRules = {
+  영단어: ['영단어', '단어장', '토익', '단어'],
+  신문스크랩: ['신문', '스크랩'],
+  러닝: ['러닝', '조깅', '달리기'],
+  자기소개서: ['자소서', '자기소개서', '에세이'],
+  코딩: ['코딩', '프로그래밍', '코드'],
+  네트워킹: ['네트워킹', '모임', '만남'],
+  자격증: ['자격증', '시험'],
+  기타: []
+};
+
+export function normalize(text) {
+  return text
+    .replace(/\s+/g, ' ')
+    .replace(/[.,!?]/g, ' ')
+    .trim();
+}
+
+export function extractDuration(text) {
+  const hourMin = text.match(/(\d+)\s*시간\s*(\d+)?\s*분?/);
+  if (hourMin) {
+    const h = parseInt(hourMin[1], 10);
+    const m = hourMin[2] ? parseInt(hourMin[2], 10) : 0;
+    return h * 3600 + m * 60;
+  }
+  const minOnly = text.match(/(\d+)\s*분/);
+  if (minOnly) {
+    return parseInt(minOnly[1], 10) * 60;
+  }
+  return 25 * 60; // default 25m
+}
+
+export function matchCategory(text) {
+  for (const [tag, keywords] of Object.entries(tagRules)) {
+    if (keywords.some((k) => text.includes(k))) {
+      return tag;
+    }
+  }
+  return '기타';
+}
+
+export function topTerms(text, n = 3) {
+  const tokens = text
+    .replace(/[^가-힣0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter((t) => t && !stopWords.has(t));
+  const freq = new Map();
+  for (const t of tokens) {
+    freq.set(t, (freq.get(t) || 0) + 1);
+  }
+  return Array.from(freq.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, n)
+    .map(([w]) => w);
+}
+
+function splitSegments(text) {
+  return text
+    .split(/(?:,|그리고|그리고|또|그리고)/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export function parseActivities(transcript) {
+  const segments = splitSegments(transcript);
+  const activities = [];
+  for (const seg of segments) {
+    const norm = normalize(seg);
+    if (!norm) continue;
+    const durationSec = extractDuration(norm);
+    const tag = matchCategory(norm);
+    const keywords = topTerms(norm);
+    activities.push({ durationSec, tag, note: seg.trim(), transcript: seg.trim(), keywords });
+  }
+  return activities;
+}

--- a/lib/nlp.test.js
+++ b/lib/nlp.test.js
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { parseActivities } from './nlp.js';
+
+test('parseActivities parses multiple segments', () => {
+  const transcript = '오늘 오전에 토익 단어 30분 외우고, 저녁에 자소서 문항 1개 40분 썼어';
+  const acts = parseActivities(transcript);
+  assert.strictEqual(acts.length, 2);
+  assert.strictEqual(acts[0].durationSec, 1800);
+  assert.strictEqual(acts[0].tag, '영단어');
+  assert.strictEqual(acts[1].durationSec, 2400);
+  assert.strictEqual(acts[1].tag, '자기소개서');
+});
+
+test('defaults duration to 25m when missing', () => {
+  const transcript = '오전에 영어 단어 외웠어';
+  const acts = parseActivities(transcript);
+  assert.strictEqual(acts[0].durationSec, 1500);
+});

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,0 +1,12 @@
+/**
+ * @typedef {'영단어'|'신문스크랩'|'러닝'|'자기소개서'|'코딩'|'네트워킹'|'자격증'|'기타'} ActivityTag
+ *
+ * @typedef {Object} Activity
+ * @property {string} [id]
+ * @property {string} [date]
+ * @property {number} durationSec
+ * @property {ActivityTag} tag
+ * @property {string} [note]
+ * @property {string} [transcript]
+ * @property {string[]} [keywords]
+ */

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "wecare-nlp",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test lib/nlp.test.js"
+  }
+}


### PR DESCRIPTION
## Summary
- implement rule-based Korean activity parsing and tagging
- add simple Node test for parser

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/typescript)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5ed905c688325acfe10159e16857d