### PR TITLE
feat: add analytics and dashboard metrics

### DIFF
--- a/wecare/App.tsx
+++ b/wecare/App.tsx
@@ -1,5 +1,10 @@
 import { Stack } from 'expo-router';
+import { useEffect } from 'react';
+import { initAnalytics } from './lib/analytics';
 
 export default function App() {
+  useEffect(() => {
+    initAnalytics();
+  }, []);
   return <Stack />;
 }

--- a/wecare/app/(tabs)/home.tsx
+++ b/wecare/app/(tabs)/home.tsx
@@ -2,7 +2,7 @@ import { View, Text, Button } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useEffect, useState } from 'react';
 import { Activity } from '../../lib/types';
-import { loadActivities } from '../../lib/storage';
+import { loadActivities, saveApplyClick } from '../../lib/storage';
 
 export default function Home() {
   const router = useRouter();
@@ -15,6 +15,7 @@ export default function Home() {
   return (
     <View style={{ flex: 1, padding: 16, gap: 12 }}>
       <Button title="음성 기록" onPress={() => router.push('/record/voice')} />
+      <Button title="지원하기" onPress={saveApplyClick} />
       {activities.map((a) => (
         <View key={a.id} style={{ marginTop: 8 }}>
           <Text>{`${a.tag} ${Math.round(a.durationSec / 60)}분`}</Text>

--- a/wecare/app/dashboard/index.tsx
+++ b/wecare/app/dashboard/index.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+import { View, Text, Button } from 'react-native';
+import { Activity } from '../../lib/types';
+import { loadActivities, loadApplyCount } from '../../lib/storage';
+
+const WEEKLY_GOAL_MIN = 150;
+const MONTHLY_GOAL_MIN = 600;
+
+function calculateStreak(acts: Activity[]): number {
+  const dates = new Set(acts.map((a) => a.date.split('T')[0]));
+  let streak = 0;
+  const day = new Date();
+  while (true) {
+    const key = day.toISOString().split('T')[0];
+    if (dates.has(key)) {
+      streak++;
+      day.setDate(day.getDate() - 1);
+    } else {
+      break;
+    }
+  }
+  return streak;
+}
+
+function sumDuration(acts: Activity[], days: number): number {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - days);
+  return acts
+    .filter((a) => new Date(a.date) >= cutoff)
+    .reduce((acc, cur) => acc + cur.durationSec, 0);
+}
+
+export default function Dashboard() {
+  const [activities, setActivities] = useState<Activity[]>([]);
+  const [applyCount, setApplyCount] = useState(0);
+  const [tab, setTab] = useState<'weekly' | 'monthly'>('weekly');
+
+  useEffect(() => {
+    loadActivities().then(setActivities);
+    loadApplyCount().then(setApplyCount);
+  }, []);
+
+  const streak = calculateStreak(activities);
+  const totalSec = tab === 'weekly' ? sumDuration(activities, 7) : sumDuration(activities, 30);
+  const totalMin = Math.round(totalSec / 60);
+  const goal = tab === 'weekly' ? WEEKLY_GOAL_MIN : MONTHLY_GOAL_MIN;
+  const progress = Math.min(100, Math.round((totalMin / goal) * 100));
+
+  return (
+    <View style={{ flex: 1, padding: 16, gap: 12 }}>
+      <View style={{ flexDirection: 'row', gap: 8 }}>
+        <Button title="주간" onPress={() => setTab('weekly')} />
+        <Button title="월간" onPress={() => setTab('monthly')} />
+      </View>
+      <Text>{`Streak: ${streak}일`}</Text>
+      <Text>{`활동 시간: ${totalMin}분`}</Text>
+      <Text>{`목표 대비 진행률: ${progress}% (${totalMin}/${goal}분)`}</Text>
+      <Text>{`지원 버튼 클릭: ${applyCount}`}</Text>
+    </View>
+  );
+}

--- a/wecare/lib/analytics.ts
+++ b/wecare/lib/analytics.ts
@@ -1,0 +1,19 @@
+import * as Amplitude from 'expo-analytics-amplitude';
+
+const API_KEY = process.env.EXPO_PUBLIC_AMPLITUDE_API_KEY || '';
+
+export function initAnalytics() {
+  if (API_KEY) {
+    Amplitude.initialize(API_KEY);
+  }
+}
+
+export function logEvent(name: string, properties?: Record<string, any>) {
+  if (API_KEY) {
+    if (properties) {
+      Amplitude.logEventWithProperties(name, properties);
+    } else {
+      Amplitude.logEvent(name);
+    }
+  }
+}

--- a/wecare/lib/storage.ts
+++ b/wecare/lib/storage.ts
@@ -1,7 +1,9 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Activity } from './types';
+import { logEvent } from './analytics';
 
 const KEY = 'activities';
+const APPLY_KEY = 'applyClicks';
 
 export async function loadActivities(): Promise<Activity[]> {
   const raw = await AsyncStorage.getItem(KEY);
@@ -12,4 +14,16 @@ export async function saveActivity(activity: Activity) {
   const list = await loadActivities();
   list.push(activity);
   await AsyncStorage.setItem(KEY, JSON.stringify(list));
+  logEvent('activity_saved', { duration: activity.durationSec, tag: activity.tag });
+}
+
+export async function loadApplyCount(): Promise<number> {
+  const raw = await AsyncStorage.getItem(APPLY_KEY);
+  return raw ? Number(raw) : 0;
+}
+
+export async function saveApplyClick() {
+  const count = await loadApplyCount();
+  await AsyncStorage.setItem(APPLY_KEY, String(count + 1));
+  logEvent('apply_click', { count: count + 1 });
 }

--- a/wecare/package.json
+++ b/wecare/package.json
@@ -13,6 +13,7 @@
     "@react-native-voice/voice": "^3.2.0",
     "@react-native-async-storage/async-storage": "^1.21.0",
     "react": "18.2.0",
-    "react-native": "0.73.4"
+    "react-native": "0.73.4",
+    "expo-analytics-amplitude": "~12.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- add amplitude analytics helper and init on app load
- log activity save and apply button clicks for KPI tracking
- introduce dashboard with weekly/monthly tabs, streaks and goal progress

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/expo-analytics-amplitude)*

------
https://chatgpt.com/codex/tasks/task_e_68a60161b2b48325b5f50ad08ae6b842