### PR TITLE
Add card-based home screen with prioritized actions

### DIFF
--- a/wecare/app/(tabs)/home.tsx
+++ b/wecare/app/(tabs)/home.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import Card from '../../components/Card';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+interface CardData {
+  key: string;
+  title: string;
+  description?: string;
+  href: string;
+  count: number;
+}
+
+const CARD_CONFIG: Omit<CardData, 'count'>[] = [
+  {
+    key: 'reflect',
+    title: 'Reflect',
+    description: 'Daily reflections',
+    href: '/reflect',
+  },
+  {
+    key: 'voice',
+    title: 'Voice',
+    description: 'Voice notes',
+    href: '/voice',
+  },
+  {
+    key: 'check',
+    title: 'Check',
+    description: 'Check-in tasks',
+    href: '/check',
+  },
+];
+
+export default function Home() {
+  const [cards, setCards] = useState<CardData[]>(
+    CARD_CONFIG.map((c) => ({ ...c, count: 0 }))
+  );
+
+  useEffect(() => {
+    async function loadCounts() {
+      try {
+        const loaded = await Promise.all(
+          CARD_CONFIG.map(async (cfg) => {
+            const stored = await AsyncStorage.getItem(`${cfg.key}Count`);
+            const count = stored ? parseInt(stored, 10) : 0;
+            return { ...cfg, count } as CardData;
+          })
+        );
+        loaded.sort((a, b) => a.count - b.count);
+        setCards(loaded);
+      } catch (e) {
+        // ignore errors, keep default ordering
+      }
+    }
+    loadCounts();
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      {cards.map((card) => (
+        <Card
+          key={card.key}
+          title={card.title}
+          description={card.description}
+          href={card.href}
+          storageKey={`${card.key}Count`}
+        />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+    backgroundColor: '#f2f2f2',
+  },
+});

--- a/wecare/components/Card.tsx
+++ b/wecare/components/Card.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Pressable, StyleSheet, Text, ViewStyle } from 'react-native';
+import { Link } from 'expo-router';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export interface CardProps {
+  title: string;
+  description?: string;
+  href: string;
+  storageKey: string;
+  style?: ViewStyle;
+}
+
+export const Card: React.FC<CardProps> = ({ title, description, href, storageKey, style }) => {
+  const handlePress = async () => {
+    try {
+      const current = await AsyncStorage.getItem(storageKey);
+      const next = current ? parseInt(current, 10) + 1 : 1;
+      await AsyncStorage.setItem(storageKey, String(next));
+    } catch (e) {
+      // ignore storage errors
+    }
+  };
+
+  return (
+    <Link href={href} asChild>
+      <Pressable onPress={handlePress} style={[styles.card, style]}
+        accessibilityRole="button">
+        <Text style={styles.title}>{title}</Text>
+        {description ? <Text style={styles.description}>{description}</Text> : null}
+      </Pressable>
+    </Link>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    padding: 16,
+    marginBottom: 12,
+    borderRadius: 8,
+    backgroundColor: '#fff',
+    elevation: 1,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 4,
+  },
+  description: {
+    fontSize: 14,
+    color: '#555',
+  },
+});
+
+export default Card;


### PR DESCRIPTION
## Summary
- add reusable `Card` component for navigation links with usage tracking
- implement home screen cards linking to reflect, voice, and check routes
- sort cards by locally stored activity counts for prioritized display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5f92b11248325ae6ae37493c18e84