### PR TITLE
Add background timer hook and recording screen

### DIFF
--- a/wecare/app/record/timer.tsx
+++ b/wecare/app/record/timer.tsx
@@ -1,0 +1,43 @@
+import { View, Text, Button } from 'react-native';
+import { useState } from 'react';
+import { useTimer } from '../../lib/useTimer';
+import { saveActivity } from '../../lib/storage';
+import { Activity } from '../../lib/types';
+
+const TARGET_SEC = 1500;
+
+function format(sec: number) {
+  const m = Math.floor(sec / 60);
+  const s = sec % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+export default function TimerScreen() {
+  const [done, setDone] = useState(false);
+
+  const handleEnd = async (durationSec: number) => {
+    const activity: Activity = {
+      id: Date.now().toString(),
+      date: new Date().toISOString(),
+      durationSec,
+      tag: '기타',
+      note: '타이머',
+      keywords: [],
+    };
+    await saveActivity(activity);
+    setDone(true);
+  };
+
+  const { elapsed, start, stop } = useTimer({ targetSec: TARGET_SEC, onEnd: handleEnd });
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', gap: 16 }}>
+      <Text>{`목표: ${format(TARGET_SEC)}`}</Text>
+      <Text>{`경과: ${format(elapsed)}`}</Text>
+      <Button title="Start" onPress={start} />
+      <Button title="Stop" onPress={stop} />
+      {done && <Text>저장 완료</Text>}
+    </View>
+  );
+}
+

--- a/wecare/lib/useTimer.ts
+++ b/wecare/lib/useTimer.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface Options {
+  targetSec: number;
+  onEnd?: (elapsedSec: number) => void;
+}
+
+export function useTimer({ targetSec, onEnd }: Options) {
+  const [elapsed, setElapsed] = useState(0);
+  const startRef = useRef<number | null>(null);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+  const tick = () => {
+    if (!startRef.current) return;
+    const diff = Math.floor((Date.now() - startRef.current) / 1000);
+    setElapsed(diff);
+    if (diff >= targetSec) {
+      stop();
+      onEnd?.(diff);
+    }
+  };
+
+  const start = () => {
+    if (startRef.current) return;
+    startRef.current = Date.now();
+    setElapsed(0);
+    tick();
+    timerRef.current = setInterval(tick, 1000);
+  };
+
+  const stop = () => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+    startRef.current = null;
+  };
+
+  useEffect(() => {
+    return stop;
+  }, []);
+
+  return { elapsed, start, stop };
+}
+


### PR DESCRIPTION
## Summary
- create `useTimer` hook to run timers in background with completion callback
- add `timer` record screen showing target and elapsed time
- persist completed timer sessions to storage as `Activity`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5f9cdc60483259e24a3d96504efdd