### PR TITLE
feat: add weekly summary dashboard

### DIFF
--- a/wecare/app/dashboard/index.tsx
+++ b/wecare/app/dashboard/index.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import { View, Text } from 'react-native';
+import Svg from 'react-native-svg';
+import { VictoryPie } from 'victory-native';
+import { loadWeeklySummary, WeeklySummary } from '../../lib/storage';
+
+export default function Dashboard() {
+  const [summary, setSummary] = useState<WeeklySummary | null>(null);
+
+  useEffect(() => {
+    loadWeeklySummary().then(setSummary);
+  }, []);
+
+  if (!summary) {
+    return <View style={{ flex: 1 }} />;
+  }
+
+  return (
+    <View style={{ flex: 1, padding: 16, gap: 16 }}>
+      <Text>{`총 활동 시간: ${Math.round(summary.total / 60)}분`}</Text>
+      <Text>{`전주 대비: ${
+        summary.percentChange >= 0 ? '+' : ''
+      }${summary.percentChange.toFixed(1)}%`}</Text>
+      <Svg width={300} height={300}>
+        <VictoryPie
+          standalone={false}
+          width={300}
+          height={300}
+          data={Object.entries(summary.byTag).map(([tag, pct]) => ({
+            x: tag,
+            y: pct,
+          }))}
+          labels={({ datum }) => `${datum.x} ${datum.y.toFixed(1)}%`}
+        />
+      </Svg>
+    </View>
+  );
+}
+

--- a/wecare/lib/storage.ts
+++ b/wecare/lib/storage.ts
@@ -1,5 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Activity } from './types';
+import { Activity, ActivityTag } from './types';
 
 const KEY = 'activities';
 
@@ -12,4 +12,60 @@ export async function saveActivity(activity: Activity) {
   const list = await loadActivities();
   list.push(activity);
   await AsyncStorage.setItem(KEY, JSON.stringify(list));
+}
+
+export interface WeeklySummary {
+  total: number;
+  percentChange: number;
+  byTag: Record<ActivityTag, number>;
+}
+
+export async function loadWeeklySummary(): Promise<WeeklySummary> {
+  const activities = await loadActivities();
+  const now = new Date();
+  const day = now.getDay();
+  const diff = day === 0 ? -6 : 1 - day; // Monday as first day
+  const startOfWeek = new Date(now);
+  startOfWeek.setDate(now.getDate() + diff);
+  startOfWeek.setHours(0, 0, 0, 0);
+  const endOfWeek = new Date(startOfWeek);
+  endOfWeek.setDate(startOfWeek.getDate() + 7);
+  const startOfPrevWeek = new Date(startOfWeek);
+  startOfPrevWeek.setDate(startOfWeek.getDate() - 7);
+
+  const currentWeek: Activity[] = [];
+  const prevWeek: Activity[] = [];
+  for (const a of activities) {
+    const d = new Date(a.date);
+    if (d >= startOfWeek && d < endOfWeek) currentWeek.push(a);
+    else if (d >= startOfPrevWeek && d < startOfWeek) prevWeek.push(a);
+  }
+
+  const total = currentWeek.reduce((sum, a) => sum + a.durationSec, 0);
+  const prevTotal = prevWeek.reduce((sum, a) => sum + a.durationSec, 0);
+  const percentChange = prevTotal
+    ? ((total - prevTotal) / prevTotal) * 100
+    : 0;
+
+  const tags: ActivityTag[] = [
+    '영단어',
+    '신문스크랩',
+    '러닝',
+    '자기소개서',
+    '코딩',
+    '네트워킹',
+    '자격증',
+    '기타',
+  ];
+  const byTag: Record<ActivityTag, number> = Object.fromEntries(
+    tags.map((t) => [t, 0]),
+  ) as Record<ActivityTag, number>;
+  for (const a of currentWeek) {
+    byTag[a.tag] += a.durationSec;
+  }
+  for (const t of tags) {
+    byTag[t] = total ? (byTag[t] / total) * 100 : 0;
+  }
+
+  return { total, percentChange, byTag };
 }

--- a/wecare/package.json
+++ b/wecare/package.json
@@ -12,6 +12,8 @@
     "expo-speech": "~12.0.0",
     "@react-native-voice/voice": "^3.2.0",
     "@react-native-async-storage/async-storage": "^1.21.0",
+    "react-native-svg": "^15.4.0",
+    "victory-native": "^36.8.0",
     "react": "18.2.0",
     "react-native": "0.73.4"
   }


### PR DESCRIPTION
## Summary
- add react-native-svg and victory-native dependencies
- compute weekly activity summary with percent change and tag distribution
- show dashboard with total time, week-over-week change, and tag pie chart

## Testing
- `npm test`
- `npm test` (missing script) in wecare
- `npm install react-native-svg victory-native` (failed: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68a5f9f058b08325a33d873439cc6a87