### PR TITLE
feat: add local nlp parser and tests

### DIFF
--- a/wecare/app/record/voice.tsx
+++ b/wecare/app/record/voice.tsx
@@ -4,6 +4,7 @@ import VoiceMic from '../../components/VoiceMic';
 import { summarizeAndTag } from '../../lib/gemini';
 import { saveActivity } from '../../lib/storage';
 import { Activity } from '../../lib/types';
+import { parseActivities } from '../../lib/nlp';
 
 export default function VoiceScreen() {
   const [transcript, setTranscript] = useState('');
@@ -12,8 +13,14 @@ export default function VoiceScreen() {
   const handleStop = async (text: string) => {
     setTranscript(text);
     try {
-      const apiKey = process.env.EXPO_PUBLIC_GEMINI_API_KEY || '';
-      const result = await summarizeAndTag(text, apiKey);
+      let result: Omit<Activity, 'id' | 'date'> | null = null;
+      const parsed = parseActivities(text)[0];
+      if (parsed) {
+        result = parsed;
+      } else {
+        const apiKey = process.env.EXPO_PUBLIC_GEMINI_API_KEY || '';
+        result = await summarizeAndTag(text, apiKey);
+      }
       const full: Activity = {
         id: Date.now().toString(),
         date: new Date().toISOString(),

--- a/wecare/lib/nlp.test.ts
+++ b/wecare/lib/nlp.test.ts
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { parseActivities } from './nlp.ts';
+
+// Ensure parseActivities returns objects shaped like Activity without id/date
+// by checking keys and basic types.
+test('parseActivities returns Activity-like objects', () => {
+  const transcript = '오늘 오전에 토익 단어 30분 외우고, 저녁에 자소서 문항 1개 40분 썼어';
+  const acts = parseActivities(transcript);
+  assert.strictEqual(acts.length, 2);
+  const act = acts[0];
+  assert.strictEqual(typeof act.durationSec, 'number');
+  assert.strictEqual(typeof act.tag, 'string');
+  assert.strictEqual(typeof act.note, 'string');
+  assert.strictEqual(typeof act.transcript, 'string');
+  assert.ok(Array.isArray(act.keywords));
+  const keys = Object.keys(act).sort();
+  assert.deepStrictEqual(keys, ['durationSec', 'keywords', 'note', 'tag', 'transcript'].sort());
+});

--- a/wecare/lib/nlp.ts
+++ b/wecare/lib/nlp.ts
@@ -1,0 +1,85 @@
+import type { Activity, ActivityTag } from './types.ts';
+
+const stopWords = new Set<string>([
+  '오늘', '오전', '저녁', '오후', '그리고', '또', '또는', '에서', '에', '를', '을', '가', '이',
+  '저', '나', '너', '한', '하나', '무슨', '몇', '개', '문항', '1개', '1', '2', '3', '4', '5'
+]);
+
+const tagRules: Record<ActivityTag, string[]> = {
+  영단어: ['영단어', '단어장', '토익', '단어'],
+  신문스크랩: ['신문', '스크랩'],
+  러닝: ['러닝', '조깅', '달리기'],
+  자기소개서: ['자소서', '자기소개서', '에세이'],
+  코딩: ['코딩', '프로그래밍', '코드'],
+  네트워킹: ['네트워킹', '모임', '만남'],
+  자격증: ['자격증', '시험'],
+  기타: []
+};
+
+export function normalize(text: string): string {
+  return text
+    .replace(/\s+/g, ' ')
+    .replace(/[.,!?]/g, ' ')
+    .trim();
+}
+
+export function extractDuration(text: string): number {
+  const hourMin = text.match(/(\d+)\s*시간\s*(\d+)?\s*분?/);
+  if (hourMin) {
+    const h = parseInt(hourMin[1], 10);
+    const m = hourMin[2] ? parseInt(hourMin[2], 10) : 0;
+    return h * 3600 + m * 60;
+  }
+  const minOnly = text.match(/(\d+)\s*분/);
+  if (minOnly) {
+    return parseInt(minOnly[1], 10) * 60;
+  }
+  return 25 * 60; // default 25m
+}
+
+export function matchCategory(text: string): ActivityTag {
+  for (const [tag, keywords] of Object.entries(tagRules) as [ActivityTag, string[]][]) {
+    if (keywords.some((k) => text.includes(k))) {
+      return tag;
+    }
+  }
+  return '기타';
+}
+
+export function topTerms(text: string, n = 3): string[] {
+  const tokens = text
+    .replace(/[^가-힣0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter((t) => t && !stopWords.has(t));
+  const freq = new Map<string, number>();
+  for (const t of tokens) {
+    freq.set(t, (freq.get(t) || 0) + 1);
+  }
+  return Array.from(freq.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, n)
+    .map(([w]) => w);
+}
+
+function splitSegments(text: string): string[] {
+  return text
+    .split(/(?:,|그리고|그리고|또|그리고)/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export function parseActivities(transcript: string): Omit<Activity, 'id' | 'date'>[] {
+  const segments = splitSegments(transcript);
+  const activities: Omit<Activity, 'id' | 'date'>[] = [];
+  for (const seg of segments) {
+    const norm = normalize(seg);
+    if (!norm) continue;
+    const durationSec = extractDuration(norm);
+    const tag = matchCategory(norm);
+    const keywords = topTerms(norm);
+    const base = seg.trim();
+    activities.push({ durationSec, tag, note: base, transcript: base, keywords });
+  }
+  return activities;
+}
+


### PR DESCRIPTION
## Summary
- port JavaScript NLP helpers to TypeScript `wecare/lib/nlp.ts`
- parse activities locally in voice recorder before Gemini fallback
- add test to ensure parsed result matches Activity shape

## Testing
- `npm test`
- `node --test --experimental-strip-types wecare/lib/nlp.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a5f9f25a9883259c87a6a633ca8734