### PR TITLE
Add jobs screen with filter chips and seed data

### DIFF
--- a/wecare/app/jobs/index.tsx
+++ b/wecare/app/jobs/index.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import { View, Text, FlatList } from 'react-native';
+import Chip from '../../components/Chip';
+import jobsData from '../../assets/jobs.json';
+
+interface Job {
+  id: string;
+  title: string;
+  location: string;
+  jobType: string;
+  closingDate: string; // ISO string
+  activityMatch: boolean;
+  recommendationScore: number;
+}
+
+function daysUntil(date: string) {
+  const diff = new Date(date).getTime() - Date.now();
+  return diff / (1000 * 60 * 60 * 24);
+}
+
+export default function JobsScreen() {
+  const [selectedLocation, setSelectedLocation] = useState<string | null>(null);
+  const [selectedJobType, setSelectedJobType] = useState<string | null>(null);
+  const [onlyClosingSoon, setOnlyClosingSoon] = useState(false);
+  const [onlyActivityMatch, setOnlyActivityMatch] = useState(false);
+
+  const jobs: Job[] = jobsData as Job[];
+  const locations = Array.from(new Set(jobs.map((j) => j.location)));
+  const jobTypes = Array.from(new Set(jobs.map((j) => j.jobType)));
+
+  const filtered = jobs
+    .filter((j) => !selectedLocation || j.location === selectedLocation)
+    .filter((j) => !selectedJobType || j.jobType === selectedJobType)
+    .filter((j) => !onlyClosingSoon || daysUntil(j.closingDate) <= 7)
+    .filter((j) => !onlyActivityMatch || j.activityMatch)
+    .sort((a, b) => b.recommendationScore - a.recommendationScore);
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <View style={{ flexDirection: 'row', flexWrap: 'wrap', marginBottom: 16 }}>
+        {locations.map((loc) => (
+          <Chip
+            key={loc}
+            label={loc}
+            selected={selectedLocation === loc}
+            onPress={() =>
+              setSelectedLocation(selectedLocation === loc ? null : loc)
+            }
+          />
+        ))}
+        {jobTypes.map((type) => (
+          <Chip
+            key={type}
+            label={type}
+            selected={selectedJobType === type}
+            onPress={() =>
+              setSelectedJobType(selectedJobType === type ? null : type)
+            }
+          />
+        ))}
+        <Chip
+          label="마감 임박"
+          selected={onlyClosingSoon}
+          onPress={() => setOnlyClosingSoon(!onlyClosingSoon)}
+        />
+        <Chip
+          label="활동 일치"
+          selected={onlyActivityMatch}
+          onPress={() => setOnlyActivityMatch(!onlyActivityMatch)}
+        />
+      </View>
+      <FlatList
+        data={filtered}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <View
+            style={{
+              padding: 12,
+              borderBottomWidth: 1,
+              borderColor: '#eee',
+            }}
+          >
+            <Text style={{ fontSize: 16, fontWeight: 'bold' }}>{item.title}</Text>
+            <Text>
+              {item.location} · {item.jobType}
+            </Text>
+            <Text>마감일: {item.closingDate}</Text>
+          </View>
+        )}
+      />
+    </View>
+  );
+}

--- a/wecare/assets/jobs.json
+++ b/wecare/assets/jobs.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "1",
+    "title": "프론트엔드 개발자",
+    "location": "서울",
+    "jobType": "개발",
+    "closingDate": "2025-08-25",
+    "activityMatch": true,
+    "recommendationScore": 95
+  },
+  {
+    "id": "2",
+    "title": "백엔드 개발자",
+    "location": "부산",
+    "jobType": "개발",
+    "closingDate": "2025-09-15",
+    "activityMatch": false,
+    "recommendationScore": 90
+  },
+  {
+    "id": "3",
+    "title": "UI/UX 디자이너",
+    "location": "서울",
+    "jobType": "디자인",
+    "closingDate": "2025-08-22",
+    "activityMatch": true,
+    "recommendationScore": 88
+  }
+]

--- a/wecare/components/Chip.tsx
+++ b/wecare/components/Chip.tsx
@@ -1,0 +1,25 @@
+import { TouchableOpacity, Text } from 'react-native';
+
+interface Props {
+  label: string;
+  selected?: boolean;
+  onPress: () => void;
+}
+
+export default function Chip({ label, selected = false, onPress }: Props) {
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      style={{
+        paddingHorizontal: 12,
+        paddingVertical: 6,
+        borderRadius: 16,
+        backgroundColor: selected ? '#0052FF' : '#eee',
+        marginRight: 8,
+        marginBottom: 8,
+      }}
+    >
+      <Text style={{ color: selected ? '#fff' : '#333' }}>{label}</Text>
+    </TouchableOpacity>
+  );
+}


### PR DESCRIPTION
## Summary
- create jobs listing screen that loads seed data and allows filtering by location, job type, closing soon, and activity match
- add reusable Chip component for toggle filters
- include seed job data JSON

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f9f23e808325b0dcadbd365baf58