### PR TITLE
feat: add home cards with routing

### DIFF
--- a/wecare/app/(tabs)/home.tsx
+++ b/wecare/app/(tabs)/home.tsx
@@ -1,20 +1,39 @@
-import { View, Text, Button } from 'react-native';
+import { View, Text } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useEffect, useState } from 'react';
 import { Activity } from '../../lib/types';
 import { loadActivities } from '../../lib/storage';
+import Card from '../../components/Card';
 
 export default function Home() {
   const router = useRouter();
   const [activities, setActivities] = useState<Activity[]>([]);
+  const [cardOrder, setCardOrder] = useState<Array<'reflect' | 'voice' | 'check'>>([
+    'reflect',
+    'voice',
+    'check',
+  ]);
 
   useEffect(() => {
-    loadActivities().then(setActivities);
+    loadActivities().then((list) => {
+      setActivities(list);
+      setCardOrder(list.length === 0 ? ['check', 'voice', 'reflect'] : ['reflect', 'voice', 'check']);
+    });
   }, []);
 
   return (
     <View style={{ flex: 1, padding: 16, gap: 12 }}>
-      <Button title="음성 기록" onPress={() => router.push('/record/voice')} />
+      {cardOrder.map((key) => {
+        const titles = { reflect: '회고', voice: '음성 기록', check: '체크인' } as const;
+        const routes = { reflect: '/reflect', voice: '/voice', check: '/check' } as const;
+        return (
+          <Card
+            key={key}
+            title={titles[key]}
+            onPress={() => router.push(routes[key])}
+          />
+        );
+      })}
       {activities.map((a) => (
         <View key={a.id} style={{ marginTop: 8 }}>
           <Text>{`${a.tag} ${Math.round(a.durationSec / 60)}분`}</Text>

--- a/wecare/components/Card.tsx
+++ b/wecare/components/Card.tsx
@@ -1,0 +1,17 @@
+import { Pressable, Text } from 'react-native';
+
+interface CardProps {
+  title: string;
+  onPress: () => void;
+}
+
+export default function Card({ title, onPress }: CardProps) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={{ padding: 16, borderRadius: 8, borderWidth: 1, borderColor: '#ddd' }}
+    >
+      <Text style={{ fontSize: 16 }}>{title}</Text>
+    </Pressable>
+  );
+}


### PR DESCRIPTION
## Summary
- create reusable Card component
- show Reflect, Voice, Check cards on home with routing
- order cards based on presence of saved activities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5fce97bc0832580d9b34dfa00cc70