### PR TITLE
Add timer screen and background timer hook

### DIFF
--- a/wecare/app/record/timer.tsx
+++ b/wecare/app/record/timer.tsx
@@ -1,0 +1,55 @@
+import { useState, useCallback } from 'react';
+import { View, Text, TextInput, Button } from 'react-native';
+import useTimer from '../../lib/useTimer';
+import { saveActivity } from '../../lib/storage';
+import { Activity } from '../../lib/types';
+
+function formatTime(sec: number) {
+  const m = Math.floor(sec / 60)
+    .toString()
+    .padStart(2, '0');
+  const s = Math.floor(sec % 60)
+    .toString()
+    .padStart(2, '0');
+  return `${m}:${s}`;
+}
+
+export default function TimerScreen() {
+  const [goal, setGoal] = useState('');
+  const goalSec = parseInt(goal) ? parseInt(goal) * 60 : 0;
+
+  const handleFinish = useCallback(async () => {
+    const activity: Activity = {
+      id: Date.now().toString(),
+      date: new Date().toISOString(),
+      durationSec: goalSec || elapsed,
+      tag: '기타',
+      note: '타이머 기록',
+      keywords: [],
+    };
+    await saveActivity(activity);
+  }, [goalSec]);
+
+  const { elapsed, isRunning, start, stop, reset } = useTimer({
+    targetSec: goalSec || undefined,
+    onFinish: handleFinish,
+  });
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', gap: 16 }}>
+      <TextInput
+        style={{ borderWidth: 1, width: 200, padding: 8, textAlign: 'center' }}
+        keyboardType="number-pad"
+        placeholder="목표 시간(분)"
+        value={goal}
+        onChangeText={setGoal}
+      />
+      <Text>{formatTime(elapsed)}</Text>
+      <View style={{ flexDirection: 'row', gap: 8 }}>
+        <Button title="시작" onPress={start} disabled={isRunning} />
+        <Button title="정지" onPress={stop} disabled={!isRunning} />
+        <Button title="리셋" onPress={reset} />
+      </View>
+    </View>
+  );
+}

--- a/wecare/lib/useTimer.ts
+++ b/wecare/lib/useTimer.ts
@@ -1,0 +1,57 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface Options {
+  targetSec?: number;
+  onFinish?: () => void;
+}
+
+export function useTimer(options: Options = {}) {
+  const [elapsed, setElapsed] = useState(0);
+  const [isRunning, setIsRunning] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const startRef = useRef<number | null>(null);
+
+  const stop = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    startRef.current = null;
+    setIsRunning(false);
+  }, []);
+
+  const tick = useCallback(() => {
+    if (startRef.current !== null) {
+      const diff = Math.floor((Date.now() - startRef.current) / 1000);
+      setElapsed(diff);
+      if (options.targetSec && diff >= options.targetSec) {
+        stop();
+        options.onFinish?.();
+      }
+    }
+  }, [options.targetSec, options.onFinish, stop]);
+
+  const start = useCallback(() => {
+    if (isRunning) return;
+    startRef.current = Date.now() - elapsed * 1000;
+    intervalRef.current = setInterval(tick, 1000);
+    setIsRunning(true);
+  }, [elapsed, isRunning, tick]);
+
+  const reset = useCallback(() => {
+    stop();
+    setElapsed(0);
+  }, [stop]);
+
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, []);
+
+  return { elapsed, isRunning, start, stop, reset };
+}
+
+export default useTimer;


### PR DESCRIPTION
## Summary
- add `useTimer` hook that tracks elapsed time in the background and exposes start/stop/reset controls
- create timer screen for entering a goal duration, showing progress, and saving an activity when finished

## Testing
- `npm test`
- `npm test` (wecare) *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a5fceb3ccc8325b6095cfc54993c07