### PR TITLE
feat: add weekly summary dashboard

### DIFF
--- a/wecare/app/dashboard/index.tsx
+++ b/wecare/app/dashboard/index.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { View, Text } from 'react-native';
+import Svg from 'react-native-svg';
+import { VictoryPie } from 'victory-native';
+import { loadWeeklySummary, WeeklySummary } from '../../lib/storage';
+
+export default function Dashboard() {
+  const [summary, setSummary] = useState<WeeklySummary | null>(null);
+
+  useEffect(() => {
+    loadWeeklySummary().then(setSummary);
+  }, []);
+
+  if (!summary) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <Text>Loading...</Text>
+      </View>
+    );
+  }
+
+  const chartData = Object.entries(summary.byTag).map(([tag, sec]) => ({
+    x: tag,
+    y: sec,
+  }));
+
+  return (
+    <View style={{ flex: 1, padding: 16, gap: 12 }}>
+      <Text>{`이번 주 합계: ${Math.round(summary.total / 60)}분`}</Text>
+      <Text>{`전주 대비 증감: ${summary.changePct.toFixed(1)}%`}</Text>
+      {chartData.length > 0 && (
+        <Svg width={250} height={250}>
+          <VictoryPie
+            standalone={false}
+            width={250}
+            height={250}
+            data={chartData}
+          />
+        </Svg>
+      )}
+    </View>
+  );
+}
+

--- a/wecare/lib/storage.ts
+++ b/wecare/lib/storage.ts
@@ -1,5 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Activity } from './types';
+import { Activity, ActivityTag } from './types';
 
 const KEY = 'activities';
 
@@ -12,4 +12,44 @@ export async function saveActivity(activity: Activity) {
   const list = await loadActivities();
   list.push(activity);
   await AsyncStorage.setItem(KEY, JSON.stringify(list));
+}
+
+export interface WeeklySummary {
+  total: number; // seconds
+  changePct: number; // percent vs previous week
+  byTag: Record<ActivityTag, number>; // seconds per tag for current week
+}
+
+export async function loadWeeklySummary(): Promise<WeeklySummary> {
+  const activities = await loadActivities();
+
+  const now = new Date();
+  const startOfWeek = new Date(now);
+  const day = startOfWeek.getDay();
+  const diffToMonday = (day + 6) % 7; // Monday as start
+  startOfWeek.setDate(startOfWeek.getDate() - diffToMonday);
+  startOfWeek.setHours(0, 0, 0, 0);
+
+  const endOfWeek = new Date(startOfWeek);
+  endOfWeek.setDate(endOfWeek.getDate() + 7);
+
+  const startOfPrevWeek = new Date(startOfWeek);
+  startOfPrevWeek.setDate(startOfPrevWeek.getDate() - 7);
+
+  const inRange = (d: Date, start: Date, end: Date) => d >= start && d < end;
+  const sum = (list: Activity[]) => list.reduce((acc, a) => acc + a.durationSec, 0);
+
+  const currWeek = activities.filter((a) => inRange(new Date(a.date), startOfWeek, endOfWeek));
+  const prevWeek = activities.filter((a) => inRange(new Date(a.date), startOfPrevWeek, startOfWeek));
+
+  const total = sum(currWeek);
+  const prevTotal = sum(prevWeek);
+  const changePct = prevTotal ? ((total - prevTotal) / prevTotal) * 100 : 0;
+
+  const byTag: Record<ActivityTag, number> = {};
+  currWeek.forEach((a) => {
+    byTag[a.tag] = (byTag[a.tag] || 0) + a.durationSec;
+  });
+
+  return { total, changePct, byTag };
 }

--- a/wecare/package.json
+++ b/wecare/package.json
@@ -13,6 +13,8 @@
     "@react-native-voice/voice": "^3.2.0",
     "@react-native-async-storage/async-storage": "^1.21.0",
     "react": "18.2.0",
-    "react-native": "0.73.4"
+    "react-native": "0.73.4",
+    "react-native-svg": "^14.1.0",
+    "victory-native": "^36.6.11"
   }
 }


### PR DESCRIPTION
## Summary
- compute weekly activity summary from AsyncStorage
- show weekly totals, week-over-week change, and tag pie chart on dashboard
- add victory-native and react-native-svg dependencies

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5fceca8708325953a1d4559e24c7b