### PR TITLE
feat: add onboarding and notification scheduling

### DIFF
--- a/wecare/app/(tabs)/home.tsx
+++ b/wecare/app/(tabs)/home.tsx
@@ -1,20 +1,72 @@
-import { View, Text, Button } from 'react-native';
+import { View, Text, Button, TextInput } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useEffect, useState } from 'react';
-import { Activity } from '../../lib/types';
-import { loadActivities } from '../../lib/storage';
+import { Activity, User } from '../../lib/types';
+import { loadActivities, loadUser, saveUser } from '../../lib/storage';
+import {
+  scheduleDailyNotification,
+  cancelNotifications,
+  registerForPushNotificationsAsync,
+} from '../notifications';
 
 export default function Home() {
   const router = useRouter();
   const [activities, setActivities] = useState<Activity[]>([]);
+  const [user, setUser] = useState<User | null>(null);
+  const [time, setTime] = useState('09:00');
 
   useEffect(() => {
     loadActivities().then(setActivities);
+    loadUser().then((u) => {
+      setUser(u);
+      setTime(u.settings.notifications.time);
+    });
   }, []);
+
+  const enable = async () => {
+    if (!(await registerForPushNotificationsAsync())) return;
+    await scheduleDailyNotification(time);
+    const updated = {
+      ...user!,
+      settings: { notifications: { enabled: true, time } },
+    };
+    await saveUser(updated);
+    setUser(updated);
+  };
+
+  const disable = async () => {
+    await cancelNotifications();
+    const updated = {
+      ...user!,
+      settings: { notifications: { enabled: false, time } },
+    };
+    await saveUser(updated);
+    setUser(updated);
+  };
 
   return (
     <View style={{ flex: 1, padding: 16, gap: 12 }}>
       <Button title="음성 기록" onPress={() => router.push('/record/voice')} />
+      {user && (
+        <View style={{ padding: 12, borderWidth: 1, borderColor: '#ccc', marginTop: 8, gap: 8 }}>
+          {user.settings.notifications.enabled ? (
+            <>
+              <Text>{`알림 시간: ${user.settings.notifications.time}`}</Text>
+              <Button title="알림 해제" onPress={disable} />
+            </>
+          ) : (
+            <>
+              <Text>알림을 받을 시간을 입력하세요 (HH:MM)</Text>
+              <TextInput
+                value={time}
+                onChangeText={setTime}
+                style={{ borderWidth: 1, padding: 8 }}
+              />
+              <Button title="알림 설정" onPress={enable} />
+            </>
+          )}
+        </View>
+      )}
       {activities.map((a) => (
         <View key={a.id} style={{ marginTop: 8 }}>
           <Text>{`${a.tag} ${Math.round(a.durationSec / 60)}분`}</Text>

--- a/wecare/app/notifications.ts
+++ b/wecare/app/notifications.ts
@@ -1,0 +1,35 @@
+import * as Notifications from 'expo-notifications';
+
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowAlert: true,
+    shouldPlaySound: false,
+    shouldSetBadge: false,
+  }),
+});
+
+export async function registerForPushNotificationsAsync() {
+  const { status: existingStatus } = await Notifications.getPermissionsAsync();
+  let finalStatus = existingStatus;
+  if (existingStatus !== 'granted') {
+    const { status } = await Notifications.requestPermissionsAsync();
+    finalStatus = status;
+  }
+  return finalStatus === 'granted';
+}
+
+export async function scheduleDailyNotification(time: string) {
+  const [hour, minute] = time.split(':').map(Number);
+  await Notifications.cancelAllScheduledNotificationsAsync();
+  await Notifications.scheduleNotificationAsync({
+    content: {
+      title: '커리어 목표 리마인더',
+      body: '오늘의 계획을 기록하세요.',
+    },
+    trigger: { hour, minute, repeats: true },
+  });
+}
+
+export async function cancelNotifications() {
+  await Notifications.cancelAllScheduledNotificationsAsync();
+}

--- a/wecare/app/onboarding/goal.tsx
+++ b/wecare/app/onboarding/goal.tsx
@@ -1,0 +1,28 @@
+import { View, Text, TextInput, Button } from 'react-native';
+import { useState, useEffect } from 'react';
+import { useRouter } from 'expo-router';
+import { loadUser, saveUser } from '../../lib/storage';
+
+export default function GoalScreen() {
+  const router = useRouter();
+  const [goal, setGoal] = useState('');
+
+  useEffect(() => {
+    loadUser().then((u) => setGoal(u.profile.goal));
+  }, []);
+
+  const handleNext = async () => {
+    const user = await loadUser();
+    const updated = { ...user, profile: { ...user.profile, goal } };
+    await saveUser(updated);
+    router.push('/onboarding/qualification');
+  };
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', padding: 16, gap: 12 }}>
+      <Text>목표를 입력하세요</Text>
+      <TextInput value={goal} onChangeText={setGoal} style={{ borderWidth: 1, padding: 8 }} />
+      <Button title="다음" onPress={handleNext} />
+    </View>
+  );
+}

--- a/wecare/app/onboarding/index.tsx
+++ b/wecare/app/onboarding/index.tsx
@@ -1,0 +1,12 @@
+import { View, Text, Button } from 'react-native';
+import { useRouter } from 'expo-router';
+
+export default function OnboardingIndex() {
+  const router = useRouter();
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', gap: 16 }}>
+      <Text>온보딩을 시작합니다</Text>
+      <Button title="시작하기" onPress={() => router.push('/onboarding/goal')} />
+    </View>
+  );
+}

--- a/wecare/app/onboarding/interest.tsx
+++ b/wecare/app/onboarding/interest.tsx
@@ -1,0 +1,28 @@
+import { View, Text, TextInput, Button } from 'react-native';
+import { useState, useEffect } from 'react';
+import { useRouter } from 'expo-router';
+import { loadUser, saveUser } from '../../lib/storage';
+
+export default function InterestScreen() {
+  const router = useRouter();
+  const [interest, setInterest] = useState('');
+
+  useEffect(() => {
+    loadUser().then((u) => setInterest(u.profile.interest));
+  }, []);
+
+  const handleDone = async () => {
+    const user = await loadUser();
+    const updated = { ...user, profile: { ...user.profile, interest } };
+    await saveUser(updated);
+    router.replace('/(tabs)/home');
+  };
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', padding: 16, gap: 12 }}>
+      <Text>관심 직무를 입력하세요</Text>
+      <TextInput value={interest} onChangeText={setInterest} style={{ borderWidth: 1, padding: 8 }} />
+      <Button title="완료" onPress={handleDone} />
+    </View>
+  );
+}

--- a/wecare/app/onboarding/qualification.tsx
+++ b/wecare/app/onboarding/qualification.tsx
@@ -1,0 +1,32 @@
+import { View, Text, TextInput, Button } from 'react-native';
+import { useState, useEffect } from 'react';
+import { useRouter } from 'expo-router';
+import { loadUser, saveUser } from '../../lib/storage';
+
+export default function QualificationScreen() {
+  const router = useRouter();
+  const [qualification, setQualification] = useState('');
+
+  useEffect(() => {
+    loadUser().then((u) => setQualification(u.profile.qualification));
+  }, []);
+
+  const handleNext = async () => {
+    const user = await loadUser();
+    const updated = { ...user, profile: { ...user.profile, qualification } };
+    await saveUser(updated);
+    router.push('/onboarding/interest');
+  };
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', padding: 16, gap: 12 }}>
+      <Text>자격을 입력하세요</Text>
+      <TextInput
+        value={qualification}
+        onChangeText={setQualification}
+        style={{ borderWidth: 1, padding: 8 }}
+      />
+      <Button title="다음" onPress={handleNext} />
+    </View>
+  );
+}

--- a/wecare/lib/storage.ts
+++ b/wecare/lib/storage.ts
@@ -1,7 +1,8 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Activity } from './types';
+import { Activity, User } from './types';
 
 const KEY = 'activities';
+const USER_KEY = 'user';
 
 export async function loadActivities(): Promise<Activity[]> {
   const raw = await AsyncStorage.getItem(KEY);
@@ -12,4 +13,18 @@ export async function saveActivity(activity: Activity) {
   const list = await loadActivities();
   list.push(activity);
   await AsyncStorage.setItem(KEY, JSON.stringify(list));
+}
+
+export async function loadUser(): Promise<User> {
+  const raw = await AsyncStorage.getItem(USER_KEY);
+  return raw
+    ? JSON.parse(raw)
+    : {
+        profile: { goal: '', qualification: '', interest: '' },
+        settings: { notifications: { enabled: false, time: '09:00' } },
+      };
+}
+
+export async function saveUser(user: User) {
+  await AsyncStorage.setItem(USER_KEY, JSON.stringify(user));
 }

--- a/wecare/lib/types.ts
+++ b/wecare/lib/types.ts
@@ -17,3 +17,21 @@ export interface Activity {
   transcript?: string;
   keywords: string[];
 }
+
+export interface UserSettings {
+  notifications: {
+    enabled: boolean;
+    time: string; // HH:MM
+  };
+}
+
+export interface UserProfile {
+  goal: string;
+  qualification: string;
+  interest: string;
+}
+
+export interface User {
+  profile: UserProfile;
+  settings: UserSettings;
+}

--- a/wecare/package.json
+++ b/wecare/package.json
@@ -10,6 +10,7 @@
     "expo": "^51.0.0",
     "expo-router": "^3.0.0",
     "expo-speech": "~12.0.0",
+    "expo-notifications": "~0.27.4",
     "@react-native-voice/voice": "^3.2.0",
     "@react-native-async-storage/async-storage": "^1.21.0",
     "react": "18.2.0",


### PR DESCRIPTION
## Summary
- add onboarding flow for goal, qualification, and interest inputs
- configure Expo notifications and daily scheduler
- store notification preferences in user settings and surface on home feed

## Testing
- `npm test`
- `cd wecare && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a6015dc49c832586b644bee2e48d50