### PR TITLE
feat: add web speech stub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+wecare/node_modules
+wecare/.expo
+dist

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # KPA_career_bloom
-A project from the Korean Psychological Association’s Empathy &amp; Innovation Camp. Career Bloom aims to help long-term job seekers overcome sunk costs, regain life satisfaction, and build meaningful career opportunities through resilience, skill development, and community support.
+
+A project from the Korean Psychological Association’s Empathy & Innovation Camp. Career Bloom aims to help long-term job seekers overcome sunk costs, regain life satisfaction, and build meaningful career opportunities through resilience, skill development, and community support.
+
+## React Native demo
+
+`wecare/` contains an Expo-based prototype that records voice, sends transcripts to Gemini for summarization and tagging, and stores the resulting activities locally.
+
+### Run
+```bash
+cd wecare
+npm install
+npx expo start
+```
+
+Set `EXPO_PUBLIC_GEMINI_API_KEY` in your environment to enable the Gemini API call.

--- a/lib/nlp.js
+++ b/lib/nlp.js
@@ -1,0 +1,83 @@
+import './types.js';
+
+const stopWords = new Set([
+  '오늘', '오전', '저녁', '오후', '그리고', '또', '또는', '에서', '에', '를', '을', '가', '이',
+  '저', '나', '너', '한', '하나', '무슨', '몇', '개', '문항', '1개', '1', '2', '3', '4', '5'
+]);
+
+const tagRules = {
+  영단어: ['영단어', '단어장', '토익', '단어'],
+  신문스크랩: ['신문', '스크랩'],
+  러닝: ['러닝', '조깅', '달리기'],
+  자기소개서: ['자소서', '자기소개서', '에세이'],
+  코딩: ['코딩', '프로그래밍', '코드'],
+  네트워킹: ['네트워킹', '모임', '만남'],
+  자격증: ['자격증', '시험'],
+  기타: []
+};
+
+export function normalize(text) {
+  return text
+    .replace(/\s+/g, ' ')
+    .replace(/[.,!?]/g, ' ')
+    .trim();
+}
+
+export function extractDuration(text) {
+  const hourMin = text.match(/(\d+)\s*시간\s*(\d+)?\s*분?/);
+  if (hourMin) {
+    const h = parseInt(hourMin[1], 10);
+    const m = hourMin[2] ? parseInt(hourMin[2], 10) : 0;
+    return h * 3600 + m * 60;
+  }
+  const minOnly = text.match(/(\d+)\s*분/);
+  if (minOnly) {
+    return parseInt(minOnly[1], 10) * 60;
+  }
+  return 25 * 60; // default 25m
+}
+
+export function matchCategory(text) {
+  for (const [tag, keywords] of Object.entries(tagRules)) {
+    if (keywords.some((k) => text.includes(k))) {
+      return tag;
+    }
+  }
+  return '기타';
+}
+
+export function topTerms(text, n = 3) {
+  const tokens = text
+    .replace(/[^가-힣0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter((t) => t && !stopWords.has(t));
+  const freq = new Map();
+  for (const t of tokens) {
+    freq.set(t, (freq.get(t) || 0) + 1);
+  }
+  return Array.from(freq.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, n)
+    .map(([w]) => w);
+}
+
+function splitSegments(text) {
+  return text
+    .split(/(?:,|그리고|그리고|또|그리고)/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export function parseActivities(transcript) {
+  const segments = splitSegments(transcript);
+  const activities = [];
+  for (const seg of segments) {
+    const norm = normalize(seg);
+    if (!norm) continue;
+    const durationSec = extractDuration(norm);
+    const tag = matchCategory(norm);
+    const keywords = topTerms(norm);
+    activities.push({ durationSec, tag, note: seg.trim(), transcript: seg.trim(), keywords });
+  }
+  return activities;
+}

--- a/lib/nlp.test.js
+++ b/lib/nlp.test.js
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { parseActivities } from './nlp.js';
+
+test('parseActivities parses multiple segments', () => {
+  const transcript = '오늘 오전에 토익 단어 30분 외우고, 저녁에 자소서 문항 1개 40분 썼어';
+  const acts = parseActivities(transcript);
+  assert.strictEqual(acts.length, 2);
+  assert.strictEqual(acts[0].durationSec, 1800);
+  assert.strictEqual(acts[0].tag, '영단어');
+  assert.strictEqual(acts[1].durationSec, 2400);
+  assert.strictEqual(acts[1].tag, '자기소개서');
+});
+
+test('defaults duration to 25m when missing', () => {
+  const transcript = '오전에 영어 단어 외웠어';
+  const acts = parseActivities(transcript);
+  assert.strictEqual(acts[0].durationSec, 1500);
+});

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,0 +1,12 @@
+/**
+ * @typedef {'영단어'|'신문스크랩'|'러닝'|'자기소개서'|'코딩'|'네트워킹'|'자격증'|'기타'} ActivityTag
+ *
+ * @typedef {Object} Activity
+ * @property {string} [id]
+ * @property {string} [date]
+ * @property {number} durationSec
+ * @property {ActivityTag} tag
+ * @property {string} [note]
+ * @property {string} [transcript]
+ * @property {string[]} [keywords]
+ */

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "wecare-nlp",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test lib/nlp.test.js"
+  }
+}

--- a/wecare/App.tsx
+++ b/wecare/App.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function App() {
+  return <Stack />;
+}

--- a/wecare/app/(tabs)/home.tsx
+++ b/wecare/app/(tabs)/home.tsx
@@ -1,0 +1,26 @@
+import { View, Text, Button } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useEffect, useState } from 'react';
+import { Activity } from '../../lib/types';
+import { loadActivities } from '../../lib/storage';
+
+export default function Home() {
+  const router = useRouter();
+  const [activities, setActivities] = useState<Activity[]>([]);
+
+  useEffect(() => {
+    loadActivities().then(setActivities);
+  }, []);
+
+  return (
+    <View style={{ flex: 1, padding: 16, gap: 12 }}>
+      <Button title="음성 기록" onPress={() => router.push('/record/voice')} />
+      {activities.map((a) => (
+        <View key={a.id} style={{ marginTop: 8 }}>
+          <Text>{`${a.tag} ${Math.round(a.durationSec / 60)}분`}</Text>
+          <Text>{a.note}</Text>
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/wecare/app/record/voice.tsx
+++ b/wecare/app/record/voice.tsx
@@ -1,0 +1,42 @@
+import { View, Text } from 'react-native';
+import { useState } from 'react';
+import VoiceMic from '../../components/VoiceMic';
+import { summarizeAndTag } from '../../lib/gemini';
+import { saveActivity } from '../../lib/storage';
+import { Activity } from '../../lib/types';
+
+export default function VoiceScreen() {
+  const [transcript, setTranscript] = useState('');
+  const [activity, setActivity] = useState<Activity | null>(null);
+
+  const handleStop = async (text: string) => {
+    setTranscript(text);
+    try {
+      const apiKey = process.env.EXPO_PUBLIC_GEMINI_API_KEY || '';
+      const result = await summarizeAndTag(text, apiKey);
+      const full: Activity = {
+        id: Date.now().toString(),
+        date: new Date().toISOString(),
+        ...result,
+      };
+      await saveActivity(full);
+      setActivity(full);
+    } catch (e) {
+      console.warn(e);
+    }
+  };
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', gap: 16 }}>
+      <VoiceMic onStop={handleStop} onTranscript={setTranscript} />
+      <Text>{transcript}</Text>
+      {activity && (
+        <View style={{ marginTop: 16, alignItems: 'center' }}>
+          <Text>{`요약: ${activity.note}`}</Text>
+          <Text>{`태그: ${activity.tag}`}</Text>
+          <Text>{`시간: ${Math.round(activity.durationSec / 60)}분`}</Text>
+        </View>
+      )}
+    </View>
+  );
+}

--- a/wecare/components/VoiceMic.tsx
+++ b/wecare/components/VoiceMic.tsx
@@ -1,0 +1,26 @@
+import { TouchableOpacity, Text } from 'react-native';
+import { useSTT } from '../lib/useSTT';
+
+interface Props {
+  onStop: (text: string) => void;
+  onTranscript?: (text: string) => void;
+}
+
+export default function VoiceMic({ onStop, onTranscript }: Props) {
+  const { isRecording, start, stop } = useSTT({ onSpeech: onTranscript });
+
+  const handlePress = async () => {
+    if (isRecording) {
+      const text = await stop();
+      onStop(text);
+    } else {
+      await start();
+    }
+  };
+
+  return (
+    <TouchableOpacity onPress={handlePress} style={{ padding: 24, borderRadius: 48, backgroundColor: '#0052FF' }}>
+      <Text style={{ color: '#fff', fontSize: 18 }}>{isRecording ? 'Stop' : 'Rec'}</Text>
+    </TouchableOpacity>
+  );
+}

--- a/wecare/lib/gemini.ts
+++ b/wecare/lib/gemini.ts
@@ -1,0 +1,25 @@
+import { Activity } from './types';
+
+const API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent';
+
+export async function summarizeAndTag(
+  transcript: string,
+  apiKey: string
+): Promise<Omit<Activity, 'id' | 'date'>> {
+  const prompt =
+    `한국어 음성 인식 결과를 활동 로그 JSON으로 변환해줘.\n` +
+    `스키마: {durationSec:number, tag:string, keywords:string[], note:string}\n` +
+    `규칙: 시간 없으면 기본 1500초(25분). 태그 매핑: {영단어|단어장|토익}->영단어,{신문|스크랩}->신문스크랩,{러닝|조깅}->러닝,{자소서|에세이}->자기소개서.\n` +
+    `입력: ${transcript}`;
+
+  const res = await fetch(`${API_URL}?key=${apiKey}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contents: [{ role: 'user', parts: [{ text: prompt }] }],
+    }),
+  });
+  const json = await res.json();
+  const text = json?.candidates?.[0]?.content?.parts?.[0]?.text || '{}';
+  return JSON.parse(text);
+}

--- a/wecare/lib/storage.ts
+++ b/wecare/lib/storage.ts
@@ -1,0 +1,15 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Activity } from './types';
+
+const KEY = 'activities';
+
+export async function loadActivities(): Promise<Activity[]> {
+  const raw = await AsyncStorage.getItem(KEY);
+  return raw ? JSON.parse(raw) : [];
+}
+
+export async function saveActivity(activity: Activity) {
+  const list = await loadActivities();
+  list.push(activity);
+  await AsyncStorage.setItem(KEY, JSON.stringify(list));
+}

--- a/wecare/lib/types.ts
+++ b/wecare/lib/types.ts
@@ -1,0 +1,19 @@
+export type ActivityTag =
+  | '영단어'
+  | '신문스크랩'
+  | '러닝'
+  | '자기소개서'
+  | '코딩'
+  | '네트워킹'
+  | '자격증'
+  | '기타';
+
+export interface Activity {
+  id: string;
+  date: string; // ISO
+  durationSec: number;
+  tag: ActivityTag;
+  note: string;
+  transcript?: string;
+  keywords: string[];
+}

--- a/wecare/lib/useSTT.native.ts
+++ b/wecare/lib/useSTT.native.ts
@@ -1,0 +1,44 @@
+import Voice from '@react-native-voice/voice';
+import { useEffect, useState } from 'react';
+
+interface Options {
+  onSpeech?: (text: string) => void;
+}
+
+export function useSTT(options: Options = {}) {
+  const [isRecording, setIsRecording] = useState(false);
+  const [transcript, setTranscript] = useState('');
+
+  useEffect(() => {
+    Voice.onSpeechResults = (e) => {
+      const t = e.value?.[0] ?? '';
+      setTranscript(t);
+      options.onSpeech?.(t);
+    };
+    return () => {
+      Voice.destroy().then(Voice.removeAllListeners);
+    };
+  }, [options.onSpeech]);
+
+  const start = async () => {
+    setTranscript('');
+    try {
+      await Voice.start('ko-KR');
+      setIsRecording(true);
+    } catch (e) {
+      console.warn(e);
+    }
+  };
+
+  const stop = async () => {
+    try {
+      await Voice.stop();
+    } catch (e) {
+      console.warn(e);
+    }
+    setIsRecording(false);
+    return transcript;
+  };
+
+  return { isRecording, transcript, start, stop };
+}

--- a/wecare/lib/useSTT.web.ts
+++ b/wecare/lib/useSTT.web.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface Options {
+  onSpeech?: (text: string) => void;
+}
+
+export function useSTT(options: Options = {}) {
+  const [isRecording, setIsRecording] = useState(false);
+  const [transcript, setTranscript] = useState('');
+  const recognitionRef = useRef<SpeechRecognition | null>(null);
+
+  useEffect(() => {
+    const SpeechRecognition =
+      (window as any).webkitSpeechRecognition || (window as any).SpeechRecognition;
+    if (SpeechRecognition) {
+      recognitionRef.current = new SpeechRecognition();
+      recognitionRef.current.lang = 'ko-KR';
+      recognitionRef.current.continuous = true;
+      recognitionRef.current.interimResults = true;
+      recognitionRef.current.onresult = (event: SpeechRecognitionEvent) => {
+        let text = '';
+        for (const res of event.results) {
+          text += res[0].transcript;
+        }
+        setTranscript(text);
+        options.onSpeech?.(text);
+      };
+    }
+    return () => {
+      recognitionRef.current?.stop();
+    };
+  }, [options.onSpeech]);
+
+  const start = async () => {
+    setTranscript('');
+    recognitionRef.current?.start();
+    setIsRecording(true);
+  };
+
+  const stop = async () => {
+    recognitionRef.current?.stop();
+    setIsRecording(false);
+    return transcript;
+  };
+
+  return { isRecording, transcript, start, stop };
+}

--- a/wecare/package.json
+++ b/wecare/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "wecare",
+  "version": "0.1.0",
+  "private": true,
+  "main": "expo",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "^51.0.0",
+    "expo-router": "^3.0.0",
+    "expo-speech": "~12.0.0",
+    "@react-native-voice/voice": "^3.2.0",
+    "@react-native-async-storage/async-storage": "^1.21.0",
+    "react": "18.2.0",
+    "react-native": "0.73.4"
+  }
+}


### PR DESCRIPTION
## Summary
- split `useSTT` into native and web versions
- implement browser SpeechRecognition stub for web builds

## Testing
- `npm test`
- `npm --prefix wecare install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@react-native-async-storage%2fasync-storage)*
- `cd wecare && npx expo export --platform web --output-dir dist` *(fails: 403 Forbidden - GET https://registry.npmjs.org/expo)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ed905c688325acfe10159e16857d