### PR TITLE
Add Card component and home navigation cards

### DIFF
--- a/wecare/app/(tabs)/home.tsx
+++ b/wecare/app/(tabs)/home.tsx
@@ -1,8 +1,10 @@
-import { View, Text, Button } from 'react-native';
+import { View, Text } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useEffect, useState } from 'react';
 import { Activity } from '../../lib/types';
 import { loadActivities } from '../../lib/storage';
+import Card from '../../components/Card';
+import { Ionicons } from '@expo/vector-icons';
 
 export default function Home() {
   const router = useRouter();
@@ -14,7 +16,21 @@ export default function Home() {
 
   return (
     <View style={{ flex: 1, padding: 16, gap: 12 }}>
-      <Button title="음성 기록" onPress={() => router.push('/record/voice')} />
+      <Card
+        text="Reflect"
+        icon={<Ionicons name="create-outline" size={24} color="black" />}
+        onPress={() => router.push('/reflect')}
+      />
+      <Card
+        text="Voice"
+        icon={<Ionicons name="mic-outline" size={24} color="black" />}
+        onPress={() => router.push('/voice')}
+      />
+      <Card
+        text="Check"
+        icon={<Ionicons name="checkmark-outline" size={24} color="black" />}
+        onPress={() => router.push('/check')}
+      />
       {activities.map((a) => (
         <View key={a.id} style={{ marginTop: 8 }}>
           <Text>{`${a.tag} ${Math.round(a.durationSec / 60)}분`}</Text>

--- a/wecare/components/Card.tsx
+++ b/wecare/components/Card.tsx
@@ -1,17 +1,29 @@
 import { Pressable, Text } from 'react-native';
+import { ReactNode } from 'react';
 
 interface CardProps {
-  title: string;
-  onPress: () => void;
+  text: string;
+  icon?: ReactNode;
+  round?: boolean;
+  onPress?: () => void;
 }
 
-export default function Card({ title, onPress }: CardProps) {
+export default function Card({ text, icon, round, onPress }: CardProps) {
   return (
     <Pressable
       onPress={onPress}
-      style={{ padding: 16, borderRadius: 8, borderWidth: 1, borderColor: '#ddd' }}
+      style={{
+        padding: 16,
+        borderRadius: round ? 999 : 8,
+        borderWidth: 1,
+        borderColor: '#ddd',
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 8,
+      }}
     >
-      <Text style={{ fontSize: 16 }}>{title}</Text>
+      {icon}
+      <Text style={{ fontSize: 16 }}>{text}</Text>
     </Pressable>
   );
 }


### PR DESCRIPTION
## Summary
- add flexible `Card` component supporting icon, text, round styling, and onPress
- display three navigation cards on home screen linking to Reflect, Voice, and Check flows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a61adf50ec83258f4e583eabfa976e