### PR TITLE
Add weekly activity summary with bar chart

### DIFF
--- a/wecare/app/dashboard/index.tsx
+++ b/wecare/app/dashboard/index.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 import { View, Text } from 'react-native';
 import Svg from 'react-native-svg';
-import { VictoryPie } from 'victory-native';
+import { VictoryBar, VictoryChart, VictoryAxis } from 'victory-native';
+import StatRow from '../../components/StatRow';
 import { loadWeeklySummary, WeeklySummary } from '../../lib/storage';
 
 export default function Dashboard() {
@@ -21,21 +22,25 @@ export default function Dashboard() {
 
   const chartData = Object.entries(summary.byTag).map(([tag, sec]) => ({
     x: tag,
-    y: sec,
+    y: Math.round(sec / 60),
   }));
 
   return (
     <View style={{ flex: 1, padding: 16, gap: 12 }}>
-      <Text>{`이번 주 합계: ${Math.round(summary.total / 60)}분`}</Text>
-      <Text>{`전주 대비 증감: ${summary.changePct.toFixed(1)}%`}</Text>
+      <StatRow label="이번 주 합계" value={`${Math.round(summary.total / 60)}분`} />
+      <StatRow label="전주 대비 증감" value={`${summary.changePct.toFixed(1)}%`} />
       {chartData.length > 0 && (
-        <Svg width={250} height={250}>
-          <VictoryPie
+        <Svg width={300} height={250}>
+          <VictoryChart
             standalone={false}
-            width={250}
+            width={300}
             height={250}
-            data={chartData}
-          />
+            domainPadding={{ x: 20 }}
+          >
+            <VictoryAxis dependentAxis tickFormat={(t) => `${t}m`} />
+            <VictoryAxis style={{ tickLabels: { angle: -45, fontSize: 10 } }} />
+            <VictoryBar data={chartData} />
+          </VictoryChart>
         </Svg>
       )}
     </View>

--- a/wecare/components/StatRow.tsx
+++ b/wecare/components/StatRow.tsx
@@ -1,0 +1,15 @@
+import { View, Text } from 'react-native';
+
+interface StatRowProps {
+  label: string;
+  value: string;
+}
+
+export default function StatRow({ label, value }: StatRowProps) {
+  return (
+    <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+      <Text style={{ fontSize: 16 }}>{label}</Text>
+      <Text style={{ fontSize: 16, fontWeight: 'bold' }}>{value}</Text>
+    </View>
+  );
+}

--- a/wecare/lib/storage.ts
+++ b/wecare/lib/storage.ts
@@ -1,5 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Activity } from './types';
+import { Activity, ActivityTag } from './types';
 
 const KEY = 'activities';
 
@@ -12,4 +12,35 @@ export async function saveActivity(activity: Activity) {
   const list = await loadActivities();
   list.push(activity);
   await AsyncStorage.setItem(KEY, JSON.stringify(list));
+}
+
+export interface WeeklySummary {
+  total: number;
+  changePct: number;
+  byTag: Record<ActivityTag, number>;
+}
+
+export async function loadWeeklySummary(): Promise<WeeklySummary> {
+  const activities = await loadActivities();
+  const now = Date.now();
+  const weekMs = 7 * 24 * 60 * 60 * 1000;
+  const currentStart = now - weekMs;
+  const prevStart = now - 2 * weekMs;
+
+  let total = 0;
+  let prev = 0;
+  const byTag: Record<ActivityTag, number> = {} as Record<ActivityTag, number>;
+
+  for (const a of activities) {
+    const t = new Date(a.date).getTime();
+    if (t >= currentStart) {
+      total += a.durationSec;
+      byTag[a.tag] = (byTag[a.tag] || 0) + a.durationSec;
+    } else if (t >= prevStart && t < currentStart) {
+      prev += a.durationSec;
+    }
+  }
+
+  const changePct = prev === 0 ? 0 : ((total - prev) / prev) * 100;
+  return { total, changePct, byTag };
 }

--- a/wecare/package.json
+++ b/wecare/package.json
@@ -13,6 +13,7 @@
     "@react-native-voice/voice": "^3.2.0",
     "@react-native-async-storage/async-storage": "^1.21.0",
     "react": "18.2.0",
-    "react-native": "0.73.4"
+    "react-native": "0.73.4",
+    "victory-native": "^36.6.7"
   }
 }


### PR DESCRIPTION
## Summary
- compute weekly totals and tag breakdown with change percentages
- display weekly stats using a new StatRow component
- visualize tag activity using a Victory bar chart and add victory-native dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a61ae0a21c83258c592d20cdb4c540